### PR TITLE
Fixes related to TrafficStars' services.

### DIFF
--- a/memmove.go
+++ b/memmove.go
@@ -1,0 +1,6 @@
+package sysvipc
+
+import "unsafe"
+
+//go:linkname memmove runtime.memmove
+func memmove(to, from unsafe.Pointer, n uintptr)

--- a/shm.go
+++ b/shm.go
@@ -170,7 +170,7 @@ func (shma *SharedMemMount) AtomicWriteUint32(v uint32) error {
 		return io.ErrShortWrite
 	}
 
-	atomic.StoreUint32((*uint32)((unsafe.Pointer)(uintptr(shma.ptr) + uintptr(shma.offset))), v)
+	atomic.StoreUint32((*uint32)((unsafe.Pointer)(uintptr(shma.ptr)+uintptr(shma.offset))), v)
 	shma.offset += 4
 	return nil
 }

--- a/shm.go
+++ b/shm.go
@@ -13,8 +13,13 @@ import "C"
 import (
 	"errors"
 	"io"
+	"sync/atomic"
 	"time"
 	"unsafe"
+)
+
+var (
+	ErrReadOnlyShm = errors.New("Read-Only shared mem attachment")
 )
 
 // SharedMem is an allocated block of memory sharable with multiple processes.
@@ -132,7 +137,7 @@ func (shma *SharedMemMount) Read(p []byte) (int, error) {
 func (shma *SharedMemMount) Write(p []byte) (int, error) {
 	if shma.readonly {
 		// see comment on readonly field above
-		return 0, errors.New("Read-Only shared mem attachment")
+		return 0, ErrReadOnlyShm
 	}
 
 	var err error
@@ -151,6 +156,35 @@ func (shma *SharedMemMount) Write(p []byte) (int, error) {
 	memmove(dest, src, (uintptr)(l))
 	shma.offset += l
 	return int(l), err
+}
+
+// AtomicWriteUint32 places an uint32 value into the shared memory
+// segment atomically (see "sync/atomic").
+func (shma *SharedMemMount) AtomicWriteUint32(v uint32) error {
+	if shma.readonly {
+		// see comment on readonly field above
+		return ErrReadOnlyShm
+	}
+
+	if (shma.length - shma.offset) < 4 {
+		return io.ErrShortWrite
+	}
+
+	atomic.StoreUint32((*uint32)((unsafe.Pointer)(uintptr(shma.ptr) + uintptr(shma.offset))), v)
+	shma.offset += 4
+	return nil
+}
+
+// AtomicReadUint32 returns an uint32 value from the current position
+// of the shared memory segment using atomic read (see "sync/atomic").
+func (shma *SharedMemMount) AtomicReadUint32() (uint32, error) {
+	if (shma.length - shma.offset) < 4 {
+		return 0, io.EOF
+	}
+
+	v := atomic.LoadUint32((*uint32)((unsafe.Pointer)(uintptr(shma.ptr) + uintptr(shma.offset))))
+	shma.offset += 4
+	return v, nil
 }
 
 // ReadByte returns a single byte from the current position in shared memory.
@@ -176,7 +210,7 @@ func (shma *SharedMemMount) UnreadByte() error {
 func (shma *SharedMemMount) WriteByte(c byte) error {
 	if shma.readonly {
 		// see comment on readonly field above
-		return errors.New("Read-Only shared mem attachment")
+		return ErrReadOnlyShm
 	}
 	if shma.offset == shma.length {
 		return io.ErrShortWrite

--- a/shm.go
+++ b/shm.go
@@ -123,7 +123,7 @@ func (shma *SharedMemMount) Read(p []byte) (int, error) {
 	src := unsafe.Pointer(uintptr(shma.ptr) + uintptr(shma.offset))
 	dest := unsafe.Pointer(&p[0])
 
-	C.memmove(dest, src, C.size_t(l))
+	memmove(dest, src, (uintptr)(l))
 	shma.offset += l
 	return int(l), err
 }
@@ -148,7 +148,7 @@ func (shma *SharedMemMount) Write(p []byte) (int, error) {
 	dest := unsafe.Pointer(uintptr(shma.ptr) + uintptr(shma.offset))
 	src := unsafe.Pointer(&p[0])
 
-	C.memmove(dest, src, C.size_t(l))
+	memmove(dest, src, (uintptr)(l))
 	shma.offset += l
 	return int(l), err
 }

--- a/shm_test.go
+++ b/shm_test.go
@@ -101,6 +101,30 @@ func TestReadAndWrite(t *testing.T) {
 	if i != 0 {
 		t.Error("wrong length", i)
 	}
+
+	_, err = mount.Seek(0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = mount.AtomicWriteUint32(0x01020304)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = mount.Seek(0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	v, err := mount.AtomicReadUint32()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if v != 0x01020304 {
+		t.Errorf("Got %v, expected %v", v, 0x01020304)
+	}
 }
 
 func TestSHMReadOnlyError(t *testing.T) {


### PR DESCRIPTION
* Fixed panic: runtime error: cgo argument has Go pointer to Go pointer
* Added support of atomic reads/writes of uint32 via shared memory