### PR TITLE
Make flexibility about ipc_perm.mode's type by each OS

### DIFF
--- a/msg.go
+++ b/msg.go
@@ -98,7 +98,7 @@ func (mq MessageQueue) Set(mqi *MQInfo) error {
 		msg_perm: C.struct_ipc_perm{
 			uid:  C.__uid_t(mqi.Perms.OwnerUID),
 			gid:  C.__gid_t(mqi.Perms.OwnerGID),
-			mode: C.ushort(mqi.Perms.Mode & 0x1FF),
+			mode: C.__mode_t(mqi.Perms.Mode & 0x1FF),
 		},
 		msg_qbytes: C.msglen_t(mqi.MaxBytes),
 	}

--- a/sem.go
+++ b/sem.go
@@ -183,7 +183,7 @@ func (ss *SemaphoreSet) Set(ssi *SemSetInfo) error {
 		sem_perm: C.struct_ipc_perm{
 			uid:  C.__uid_t(ssi.Perms.OwnerUID),
 			gid:  C.__gid_t(ssi.Perms.OwnerGID),
-			mode: C.ushort(ssi.Perms.Mode & 0x1FF),
+			mode: C.__mode_t(ssi.Perms.Mode & 0x1FF),
 		},
 	}
 

--- a/shm.go
+++ b/shm.go
@@ -82,7 +82,7 @@ func (shm *SharedMem) Set(info *SHMInfo) error {
 		shm_perm: C.struct_ipc_perm{
 			uid:  C.__uid_t(info.Perms.OwnerUID),
 			gid:  C.__gid_t(info.Perms.OwnerGID),
-			mode: C.ushort(info.Perms.Mode & 0x1FF),
+			mode: C.__mode_t(info.Perms.Mode & 0x1FF),
 		},
 	}
 


### PR DESCRIPTION
This PR fix some mode type to C.__mode_t from C.ushort.

Because some OS version got diffrente type of ipc_perm.mode.

for example, I got error like this on previous master version

```
/go/pkg/mod/github.com/teepark/go-sysvipc@v0.0.0-20200817232735-d7ca6053ea29/msg.go:101:4: cannot use _Ctype_ushort(mqi.Perms.Mode & 511) (type _Ctype_ushort) as type _Ctype_uint in field value
/go/pkg/mod/github.com/teepark/go-sysvipc@v0.0.0-20200817232735-d7ca6053ea29/sem.go:186:4: cannot use _Ctype_ushort(ssi.Perms.Mode & 511) (type _Ctype_ushort) as type _Ctype_uint in field value
/go/pkg/mod/github.com/teepark/go-sysvipc@v0.0.0-20200817232735-d7ca6053ea29/shm.go:85:4: cannot use _Ctype_ushort(info.Perms.Mode & 511) (type _Ctype_ushort) as type _Ctype_uint in field value
```

The error occurs because, the OS of golang:latest container's ipc_perm.mode is uint but current code is specified by ushort.

So, for OS type-specific flexibility, I think it shoud use the `__mode_t` type.
